### PR TITLE
Pin PyYaml version

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -12,4 +12,5 @@ dependencies:
   - drmaa==0.7.9
   - snakemake==6.4.1
   - biopython>=1.78
+  - pyyaml==5.4.1
   - pip

--- a/mamba-env.yaml
+++ b/mamba-env.yaml
@@ -11,4 +11,5 @@ dependencies:
   - drmaa==0.7.9
   - snakemake==6.4.1
   - biopython>=1.78
+  - pyyaml==5.4.1
   - pip


### PR DESCRIPTION
Pinned the PyYaml version to 5.4.1 as a workaround for the yaml.load() breaking change introduced in PyYaml 6.0

We should update this when convenient to support the new yaml.load() function